### PR TITLE
ADM remediating 2 vulnerabilities

### DIFF
--- a/jeepay-payment/pom.xml
+++ b/jeepay-payment/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.jeequan</groupId>
             <artifactId>jeepay-sdk-java</artifactId>
-            <version>pls-1.3.0</version>
+            <version>pls-1.4.0</version>
         </dependency>
 
     </dependencies>

--- a/jeepay-z-codegen/pom.xml
+++ b/jeepay-z-codegen/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>8.0.31</version>
         </dependency>
 
         <dependency>
@@ -36,13 +36,13 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>4.3.10.RELEASE</version>
+            <version>5.2.23.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-generator</artifactId>
-            <version>3.3.0</version>
+            <version>3.4.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.4.8</version>
+    <version>2.7.10</version>
   </parent>
 
   <!-- 声明子项目 -->
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.jeequan</groupId>
             <artifactId>jeepay-sdk-java</artifactId>
-            <version>${jeepay.sdk.java.version}</version>
+            <version>pls-1.4.0</version>
         </dependency>
 
         <!-- alibaba FastJSON -->
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>${spring.security.version}</version>
+            <version>5.7.8</version>
         </dependency>
 
         <!-- JWT  -->
@@ -121,19 +121,19 @@
         <dependency>
             <groupId>com.github.binarywang</groupId>
             <artifactId>weixin-java-pay</artifactId>
-            <version>${binarywang.weixin.java.version}</version>
+            <version>4.4.9.B</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.binarywang</groupId>
             <artifactId>weixin-java-mp</artifactId>
-            <version>${binarywang.weixin.java.version}</version>
+            <version>4.4.9.B</version>
         </dependency>
 
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-boot-starter</artifactId>
-            <version>${mybatis.plus.starter.version}</version>
+            <version>3.5.3.1</version>
         </dependency>
 
         <!-- 生成二维码依赖 -->


### PR DESCRIPTION
Vulnerabilities:
* CVE-2022-22976, CVE-2022-22978: org.springframework.security:spring-security-core:5.4.7
* -: com.baomidou:mybatis-plus-generator:3.3.0
* -: com.github.binarywang:weixin-java-mp:4.3.9.B
* -: com.baomidou:mybatis-plus-boot-starter:3.4.2
* -: com.jeequan:jeepay-sdk-java:pls-1.3.0
* -: mysql:mysql-connector-java:8.0.28
* -: com.baomidou:mybatis-plus-boot-starter:3.4.2
* -: com.baomidou:mybatis-plus-boot-starter:3.4.2
* -: org.springframework:spring-context:4.3.10.RELEASE
* -: com.github.binarywang:weixin-java-pay:4.3.9.B
* -: mysql:mysql-connector-java:8.0.28

Dependencies upgraded:
* com.baomidou:mybatis-plus-boot-starter:3.4.2 -> 3.5.3.1
* com.baomidou:mybatis-plus-boot-starter:3.4.2 -> 3.5.3.1
* com.baomidou:mybatis-plus-boot-starter:3.4.2 -> 3.5.3.1
* com.baomidou:mybatis-plus-generator:3.3.0 -> 3.4.1
* com.github.binarywang:weixin-java-mp:4.3.9.B -> 4.4.9.B
* com.github.binarywang:weixin-java-pay:4.3.9.B -> 4.4.9.B
* com.jeequan:jeepay-sdk-java:pls-1.3.0 -> pls-1.4.0
* mysql:mysql-connector-java:8.0.28 -> 8.0.31
* mysql:mysql-connector-java:8.0.28 -> 8.0.31
* org.springframework.security:spring-security-core:5.4.7 -> 5.7.8
* org.springframework:spring-context:4.3.10.RELEASE -> 5.2.23.RELEASE

Auto-merge is enabled